### PR TITLE
capistranoのdeploy.rbにlog-level追加

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -43,3 +43,5 @@ namespace :deploy do
   before :starting, 'deploy:upload'
   after :finishing, 'deploy:cleanup'
 end
+
+set :log_level, :debug


### PR DESCRIPTION
# what
capistranoエラーのためlog-levelをdeploy.rbに追加
# why
デプロイにエラーが起きているため